### PR TITLE
Upgrade for compliance with Grails 2.4.0.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -3,6 +3,41 @@
 	<classpathentry kind="src" path="grails-app/conf"/>
 	<classpathentry kind="src" path="grails-app/taglib"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" path=".link_to_grails_plugins/jquery-1.11.1/grails-app/assets">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="BuildConfig.groovy|*DataSource.groovy|UrlMappings.groovy|Config.groovy|BootStrap.groovy|spring/resources.groovy" kind="src" path=".link_to_grails_plugins/jquery-1.11.1/grails-app/conf">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".link_to_grails_plugins/jquery-1.11.1/grails-app/services">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".link_to_grails_plugins/jquery-1.11.1/grails-app/taglib">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".link_to_grails_plugins/jquery-1.11.1/src/groovy">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".link_to_grails_plugins/release-3.0.1/src/groovy">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path=".link_to_grails_plugins/release-3.0.1/src/java">
+		<attributes>
+			<attribute name="org.grails.ide.eclipse.core.SOURCE_FOLDER" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.grails.ide.eclipse.core.CLASSPATH_CONTAINER"/>
 	<classpathentry kind="output" path="target/eclipseclasses"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -22,4 +22,11 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
 	</natures>
+	<linkedResources>
+		<link>
+			<name>.link_to_grails_plugins</name>
+			<type>2</type>
+			<location>C:/Users/mpiela.CORE1/git/twoby4/grails-jquery-ui/target/plugins</location>
+		</link>
+	</linkedResources>
 </projectDescription>

--- a/JqueryUiGrailsPlugin.groovy
+++ b/JqueryUiGrailsPlugin.groovy
@@ -3,12 +3,12 @@ class JqueryUiGrailsPlugin {
     static JQUERYUI_VERSION = "1.10.3"
 
     // Put in here the minor revision of this plugin
-    static PLUGIN_MINOR_REVISION = ""
+    static PLUGIN_MINOR_REVISION = "1"
 
     // the version attribute must be constant, so manually update this to be
     // JQUERYUI_VERSION and PLUGIN_MINOR_REVISION concatenated, with a '.'
     // if PLUGIN_MINOR_REVISION isn't blank
-    def version = '1.10.3'
+    def version = '1.10.3.1'
 
 
     def grailsVersion = "1.3 > *"

--- a/application.properties
+++ b/application.properties
@@ -1,2 +1,2 @@
-app.grails.version=2.0.4
+app.grails.version=2.4.0
 app.name=jQueryUI

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -16,9 +16,9 @@ grails.project.dependency.resolution = {
 
 	plugins {
 
-		runtime ':jquery:1.10.2'
+		runtime ':jquery:1.11.1'
 
-		build ':release:2.2.1', ':rest-client-builder:1.0.3', {
+		build ':release:3.0.1', ':rest-client-builder:2.0.1', {
 			export = false
 		}
 	}

--- a/grails-app/conf/JqueryUiPluginResources.groovy
+++ b/grails-app/conf/JqueryUiPluginResources.groovy
@@ -1,6 +1,6 @@
 // Resource declarations for Resources plugin
 // This is a bit ugly, we'll find a way to make this better in future
-def appCtx = org.codehaus.groovy.grails.commons.ApplicationHolder.application.mainContext
+def appCtx = grails.util.Holders.grailsApplication.mainContext
 def plugin = appCtx.pluginManager.getGrailsPlugin('jquery-ui')
 def jqver = plugin.instance.JQUERYUI_VERSION
 


### PR DESCRIPTION
Removed deprecated 'ApplicationHolder' reference. Upgraded jQuery plugin version.
