### PR TITLE
Fixing some errors in grails 2.4.x

### DIFF
--- a/grails-app/conf/JqueryUiPluginResources.groovy
+++ b/grails-app/conf/JqueryUiPluginResources.groovy
@@ -1,7 +1,8 @@
+import grails.util.Holders
 // Resource declarations for Resources plugin
 // This is a bit ugly, we'll find a way to make this better in future
-def appCtx = org.codehaus.groovy.grails.commons.ApplicationHolder.application.mainContext
-def plugin = appCtx.pluginManager.getGrailsPlugin('jquery-ui')
+def grailsPluginManager = Holders.getPluginManager()
+def plugin = grailsPluginManager.getGrailsPlugin('jquery-ui')
 def jqver = plugin.instance.JQUERYUI_VERSION
 
 modules = {


### PR DESCRIPTION
resource.ResourceProcessor Unable to load resources
groovy.lang.MissingMethodException: No signature of method: groovy.util.ConfigObject.getGrailsPlugin() is applicable for argument types: (java.lang.String) values: [jquery-ui]
